### PR TITLE
Remove internal links, update network booleans, and clarify UTM availability

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -60,10 +60,16 @@ To generate the entity id by hand, use the following string template:
 
 + The `{network}` variable must be be one of:
     + `adwords`
+    + `amazon`
     + `bing_ads`
-    + `twitter`
-    + `linkedin`
     + `facebook`
+    + `gemini` (not available in cross-network reporting; see Build Report V1)
+    + `google_analytics` (not available in cross-network reporting; see Build Report V1)
+    + `linkedin`
+    + `pinterest`
+    + `quora`
+    + `spotify`
+    + `twitter`
     + `adstage` (with entities managed on the AdStage platform: `account_group`, `user`, `organization` and `folder`)
 + The `{entity_level}` variable must be one of:
     + `account`
@@ -1007,7 +1013,7 @@ To request a single, flattened objective field, append a dot and the key name, s
 Gives information about the type or subtype for an entity as designated by the remote network.
 For example, a LinkedIn campaign may have the `campaign_type` of `SSU`, a LinkedIn API designated campaign type.
 Note that the `type` field is an exception and refers to an AdStage generated entity category, such as `network_ad`, rather than a remote network designated category.
-See [Entity IDs](entity-ids) for more information.
+See the Entity IDs section for more information.
 
 | UI Display Name        | API Field Name                 |
 | ---------------------- | ------------------------------ |
@@ -1052,6 +1058,9 @@ Gives information about various URLs associated with an ad.
 
 #### UTM Tracking Information
 
+**Note: UTM tracking information is only available if AdStage Join has been added to your AdStage plan and a Join task has been completed for the entity.
+Currently, Join available only as a paid Add-On.**
+
 Gives information about the UTM parameters associated with the entity.
 Note that AdStage stores these parameters formatted as JSON in `tracking_params`.
 To request a single, flattened parameter, append a dot and the key name, such as `tracking_params.utm_term`.
@@ -1089,16 +1098,22 @@ This endpoint provides information on the names and formats of cross-channel (`a
                 + tooltip: "Clicks shows how many times a user clicked on your ad" (string) - additional details about a metric, if available
                 + format: "DEFAULT", "PERCENTAGE", "CURRENCY", "TEXT", "DECIMAL", "INTEGER" (enum[string]) - format for the metric (default is `INTEGER`)
                 + type: "METRIC", "TEXT" (enum[string]) - whether the descriptor is for a metric or metadata
-                + `is_adwords`: true (string) - if the metric is valid for the adwords network
-                + `is_facebook`: true (string) - if the metric is valid for the facebook network
-                + `is_linkedin`: true (string) - if the metric is valid for the linkedin network
-                + `is_bing_ads`: true (string) - if the metric is valid for the bing ads network
-                + `is_twitter`: true (string) - if the metric is valid for the twitter network
-                + `is_account`: true (string) - if the metric is valid for the account reporting level
-                + `is_campaign`: true (string) - if the metric is valid for the campaign reporting level
-                + `is_ad_group`: true (string) - if the metric is valid for the ad group reporting level
-                + `is_ad`: true (string) - if the metric is valid for the ad reporting level
-                + `is_keyword`: true (string) - if the metric is valid for keyword reporting level
+                + `is_adwords`: true (boolean) - if the metric is valid for the `adwords` network
+                + `is_amazon`: true (boolean) - if the metric is valid for the `amazon` network
+                + `is_bing_ads`: true (boolean) - if the metric is valid for the `bing_ads` network
+                + `is_facebook`: true (boolean) - if the metric is valid for the `facebook` network
+                + `is_gemini`: false (boolean) - if the metric is valid for the `gemini` network
+                + `is_google_analytics`: false (boolean) - if the metric is valid for the `google_analytics` network
+                + `is_linkedin`: true (boolean) - if the metric is valid for the `linkedin` network
+                + `is_pinterest`: true (boolean) - if the metric is valid for the `pinterest` network
+                + `is_quora`: true (boolean) - if the metric is valid for the `quora` network
+                + `is_spotify`: true (boolean) - if the metric is valid for the `spotify` network
+                + `is_twitter`: true (boolean) - if the metric is valid for the `twitter` network
+                + `is_account`: true (boolean) - if the metric is valid for the account reporting level
+                + `is_campaign`: true (boolean) - if the metric is valid for the campaign reporting level
+                + `is_ad_group`: true (boolean) - if the metric is valid for the ad group reporting level
+                + `is_ad`: true (boolean) - if the metric is valid for the ad reporting level
+                + `is_keyword`: true (boolean) - if the metric is valid for keyword reporting level
 
     + Body
 
@@ -1114,9 +1129,15 @@ This endpoint provides information on the names and formats of cross-channel (`a
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": true,
+                    "is_amazon": true,
                     "is_bing_ads": true,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": true,
+                    "is_pinterest": true,
+                    "is_quora": true,
+                    "is_spotify": true,
                     "is_twitter": true,
                     "is_account": true,
                     "is_campaign": true,
@@ -1136,9 +1157,15 @@ This endpoint provides information on the names and formats of cross-channel (`a
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": true,
+                    "is_amazon": true,
                     "is_bing_ads": true,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": true,
+                    "is_pinterest": true,
+                    "is_quora": true,
+                    "is_spotify": true,
                     "is_twitter": true,
                     "is_account": true,
                     "is_campaign": true,
@@ -1158,9 +1185,15 @@ This endpoint provides information on the names and formats of cross-channel (`a
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": true,
+                    "is_amazon": true,
                     "is_bing_ads": true,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": true,
+                    "is_pinterest": true,
+                    "is_quora": true,
+                    "is_spotify": true,
                     "is_twitter": true,
                     "is_account": true,
                     "is_campaign": true,
@@ -1202,28 +1235,32 @@ Additionally, non-AdStage network provider metrics do not distinguish between me
         + descriptors (array)
             + (object)
                 + id: "clicks" (string) - the identifier assigned to the metric in reports
-                + short_name: "Clicks" (string) - a short human readable name for the metric
-                + display_names: ["Clicks"] (array[string]) - the network's list of allowable human readable display names for the metric; this key is omitted unless `adwords` was specified for the `network` param
+                + `short_name`: "Clicks" (string) - a short human readable name for the metric
+                + `display_names`: ["Clicks"] (array[string]) - the network's list of allowable human readable display names for the metric; this key is omitted unless `adwords` was specified for the `network` param
                 + name: "Clicks" (string) - the full human readable name for the metric used in AdStage UIs
                 + tooltip: "Clicks shows how many times a user clicked on your ad" (string) - additional details about a metric, if available
                 + format: "DEFAULT", "PERCENTAGE", "CURRENCY", "TEXT", "DECIMAL", "INTEGER" (enum[string]) - format for the metric (default is `INTEGER`)
                 + type: "METRIC", "TEXT" (enum[string]) - whether the descriptor is for a metric or metadata
-                + can_filter: true (boolean) - if the metric is allowed to be used in a filter field for a reporting request; this key is omitted unless `gemini` was specified for the `network` param
+                + `can_filter`: true (boolean) - if the metric is allowed to be used in a filter field for a reporting request; this key is omitted unless `gemini` was specified for the `network` param
                 + supports_filters: ["ACCOUNT_PERFORMANCE_REPORT"] (array[string]) - a list of all reports on the provider's network that allow filtering on the metric; this key is omitted unless `adwords` was specified for the `network` param
                 + supports_zero_impressions: ["ACCOUNT_PERFORMANCE_REPORT"] (array[string]) - a list of all reports on the provider's network that maintain metrics even when the ad entity has not logged any impressions; this key is omitted unless `adwords` was specified for the `network` param
                 + reports: ["ACCOUNT_PERFORMANCE_REPORT"] (array[string]) - a list of all reports on the provider's network that provide data for the metric; this key is omitted unless `adwords` was specified for the `network` param
-                + is_adwords: true (boolean) - if the metric is valid for the Google Ads network
-                + is_bing_ads: true (boolean) - if the metric is valid for the Microsoft Ads network
-                + is_facebook: true (boolean) - if the metric is valid for the Facebook network
-                + is_gemini: false (boolean) - if the metric is valid for the Gemini network; this key is omitted unless `gemini` was specified for the `network` param
-                + is_google_analytics: false (boolean) - if the metric is valid for the Google Analytics network; this key is omitted unless `google_analytics` was specified for the `network` param
-                + is_linkedin: true (boolean) - if the metric is valid for the LinkedIn network
-                + is_twitter: true (boolean) - if the metric is valid for the Twitter network
-                + is_account: true (boolean) - if the metric is valid for the account reporting level
-                + is_campaign: true (boolean) - if the metric is valid for the campaign reporting level
-                + is_ad_group: true (boolean) - if the metric is valid for the ad group reporting level
-                + is_ad: true (boolean) - if the metric is valid for the ad reporting level
-                + is_keyword: true (boolean) - if the metric is valid for keyword reporting level
+                + `is_adwords`: true (boolean) - if the metric is valid for the `adwords` network
+                + `is_amazon`: true (boolean) - if the metric is valid for the `amazon` network
+                + `is_bing_ads`: true (boolean) - if the metric is valid for the `bing_ads` network
+                + `is_facebook`: true (boolean) - if the metric is valid for the `facebook` network
+                + `is_gemini`: false (boolean) - if the metric is valid for the `gemini` network
+                + `is_google_analytics`: false (boolean) - if the metric is valid for the `google_analytics` network
+                + `is_linkedin`: true (boolean) - if the metric is valid for the `linkedin` network
+                + `is_pinterest`: true (boolean) - if the metric is valid for the `pinterest` network
+                + `is_quora`: true (boolean) - if the metric is valid for the `quora` network
+                + `is_spotify`: true (boolean) - if the metric is valid for the `spotify` network
+                + `is_twitter`: true (boolean) - if the metric is valid for the `twitter` network
+                + `is_account`: true (boolean) - if the metric is valid for the account reporting level
+                + `is_campaign`: true (boolean) - if the metric is valid for the campaign reporting level
+                + `is_ad_group`: true (boolean) - if the metric is valid for the ad group reporting level
+                + `is_ad`: true (boolean) - if the metric is valid for the ad reporting level
+                + `is_keyword`: true (boolean) - if the metric is valid for keyword reporting level
 
     + Body
 
@@ -1239,9 +1276,15 @@ Additionally, non-AdStage network provider metrics do not distinguish between me
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": false,
+                    "is_amazon": false,
                     "is_bing_ads": false,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": false,
+                    "is_pinterest": false,
+                    "is_quora": false,
+                    "is_spotify": false,
                     "is_twitter": false,
                     "is_account": true,
                     "is_campaign": true,
@@ -1263,9 +1306,15 @@ Additionally, non-AdStage network provider metrics do not distinguish between me
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": false,
+                    "is_amazon": false,
                     "is_bing_ads": false,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": false,
+                    "is_pinterest": false,
+                    "is_quora": false,
+                    "is_spotify": false,
                     "is_twitter": false,
                     "is_account": true,
                     "is_campaign": true,
@@ -1309,7 +1358,7 @@ This type of report will return one row per requested entity with metrics aggreg
         + `date_range`: "last 30 days" (string, required)
 
             An AdStage date range string.
-            See the [Date Ranges](date-ranges) section for details about allowed date range formats.
+            See the Date Ranges section for details about allowed date range formats.
 
         + limit: 10 (number) - number of rows to include
         + `sort_by`: "clicks" (string) - metric name/meta name to sort by
@@ -1479,7 +1528,7 @@ The request is the same as a standard report but using the `"aggregate_by"` opti
         + `date_range`: "last 30 days" (string, required)
 
             An AdStage date range string.
-            See the [Date Ranges](date-ranges) section for details about allowed date range formats.
+            See the Date Ranges section for details about allowed date range formats.
 
         + limit: 10 (number) - number of rows to include
         + `sort_by`: "clicks" (string) - metric name/meta name to sort by
@@ -1690,7 +1739,7 @@ This requires a few steps to get data flowing:
 
 Creates a custom metric descriptor to allow data upload and returns the URL which will accept metric data for the new descriptor.
 This step only needs to be performed once per conversion column - the metric descriptor can be reused across multiple data uploads.
-To get a list of existing conversion columns, see the [Discovering Metrics](discovering-metrics) section.
+To get a list of existing conversion columns, see the Discovering Metrics section.
 
 + Parameters
 
@@ -1719,15 +1768,15 @@ To get a list of existing conversion columns, see the [Discovering Metrics](disc
 
 + Response 201
 
-    Note that in the response, the id is returned as `custom_conversions:{fetch id}:conversions`.
-    You can use the link to find the appropriate URL for upload in Step 3 of the conversion upload process.
+    Note that in the response, the id is returned as `custom_conversions:{fetch_id}:conversions`.
+    You can use the link to find the appropriate URL for upload in Step 2 of the conversion upload process.
 
     + Attributes
 
-        + id: "custom_conversions:14:conversions" (string) - the raw metric name returned in reports (see [Getting Report](#reference/0/building-reports/getting-report) )
+        + id: "custom_conversions:14:conversions" (string) - the raw metric id returned in reports (see the Building Reports section)
         + `_links` (object)
             + `adstage:custom_conversion_upload` (object)
-                + href: "https://platform.adstage.io/api/organizations/40/metric_descriptors/14/conversions" (string) - the URL for step 3.
+                + href: "https://platform.adstage.io/api/organizations/40/metric_descriptors/14/conversions" (string) - the URL for uploading data in step 2.
 
     + Body
 
@@ -1773,14 +1822,14 @@ Alternatively, the V2 endpoint implements an automatic roll up feature.
             + (object)
                 + `timestamp`: `"2016-02-03T03:40Z"` (string, required) - ISO8061 formatted string representing when the conversion occurred.
                 + `value`: 30.5 (number) - An optional conversion value, expressed in the currency type for the converting account. Used to compute Return on Ad Spend.
-                + `attribution` - A list of key/value pairs where the key is an [AdStage Entity ID](entity-ids) and the value is a multiplier of how much to weigh the conversion. Use 1 unless you want to do multi-touch attribution modeling.
+                + `attribution` - A list of key/value pairs where the key is an AdStage Entity ID and the value is a multiplier of how much to weigh the conversion. Use 1 unless you want to do multi-touch attribution modeling.
                     + `/network/adwords/campaign/530303`: 1 (number) - (this id is just an example; use valid ids)
                     + `/network/adwords/acount/530303`: 1 (number) - (this id is just an example; use valid ids)
 
         + `date_range`: `"last 30 days"` (string, required)
 
             An AdStage date range string.
-            See the [Date Ranges](date-ranges) section for details about allowed date range formats.
+            See the Date Ranges section for details about allowed date range formats.
 
     + Body
 
@@ -1845,16 +1894,22 @@ Additionally, AdStage will automatically derive several metrics that are listed 
                 + tooltip: "Clicks shows how many times a user clicked on your ad" (string) - additional details about a metric, if available
                 + format: "DEFAULT", "PERCENTAGE", "CURRENCY", "TEXT", "DECIMAL", "INTEGER" (enum[string]) - format for the metric (default is `INTEGER`)
                 + type: "METRIC", "TEXT" (enum[string]) - whether the descriptor is for a metric or metadata
-                + `is_adwords`: true (string) - if the metric is valid for the adwords network
-                + `is_facebook`: true (string) - if the metric is valid for the facebook network
-                + `is_linkedin`: true (string) - if the metric is valid for the linkedin network
-                + `is_bing_ads`: true (string) - if the metric is valid for the bing ads network
-                + `is_twitter`: true (string) - if the metric is valid for the twitter network
-                + `is_account`: true (string) - if the metric is valid for the account reporting level
-                + `is_campaign`: true (string) - if the metric is valid for the campaign reporting level
-                + `is_ad_group`: true (string) - if the metric is valid for the ad group reporting level
-                + `is_ad`: true (string) - if the metric is valid for the ad reporting level
-                + `is_keyword`: true (string) - if the metric is valid for keyword reporting level
+                + `is_adwords`: true (boolean) - if the metric is valid for the `adwords` network
+                + `is_amazon`: true (boolean) - if the metric is valid for the `amazon` network
+                + `is_bing_ads`: true (boolean) - if the metric is valid for the `bing_ads` network
+                + `is_facebook`: true (boolean) - if the metric is valid for the `facebook` network
+                + `is_gemini`: false (boolean) - if the metric is valid for the `gemini` network
+                + `is_google_analytics`: false (boolean) - if the metric is valid for the `google_analytics` network
+                + `is_linkedin`: true (boolean) - if the metric is valid for the `linkedin` network
+                + `is_pinterest`: true (boolean) - if the metric is valid for the `pinterest` network
+                + `is_quora`: true (boolean) - if the metric is valid for the `quora` network
+                + `is_spotify`: true (boolean) - if the metric is valid for the `spotify` network
+                + `is_twitter`: true (boolean) - if the metric is valid for the twitter network
+                + `is_account`: true (boolean) - if the metric is valid for the account reporting level
+                + `is_campaign`: true (boolean) - if the metric is valid for the campaign reporting level
+                + `is_ad_group`: true (boolean) - if the metric is valid for the ad group reporting level
+                + `is_ad`: true (boolean) - if the metric is valid for the ad reporting level
+                + `is_keyword`: true (boolean) - if the metric is valid for keyword reporting level
 
     + Body
 
@@ -1870,9 +1925,15 @@ Additionally, AdStage will automatically derive several metrics that are listed 
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": true,
+                    "is_amazon": true,
                     "is_bing_ads": true,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": true,
+                    "is_pinterest": true,
+                    "is_quora": true,
+                    "is_spotify": true,
                     "is_twitter": true,
                     "is_account": true,
                     "is_campaign": true,
@@ -1893,9 +1954,15 @@ Additionally, AdStage will automatically derive several metrics that are listed 
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": true,
+                    "is_amazon": true,
                     "is_bing_ads": true,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": true,
+                    "is_pinterest": true,
+                    "is_quora": true,
+                    "is_spotify": true,
                     "is_twitter": true,
                     "is_account": true,
                     "is_campaign": true,
@@ -1916,9 +1983,15 @@ Additionally, AdStage will automatically derive several metrics that are listed 
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": true,
+                    "is_amazon": true,
                     "is_bing_ads": true,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": true,
+                    "is_pinterest": true,
+                    "is_quora": true,
+                    "is_spotify": true,
                     "is_twitter": true,
                     "is_account": true,
                     "is_campaign": true,
@@ -1947,7 +2020,8 @@ There are two steps required to set up a new Custom Conversion in the API:
 
 **Note that this endpoint is identical to the V1 endpoint.
 Its documentation has been copied here for convenience in explaining the custom conversion upload flow.
-AdStage may choose to release a V2 namespaced endpoint with a different feature set and shape in the future.**
+AdStage may choose to release a V2 namespaced endpoint with a different feature set and shape in the future.
+Given this, note that the link returned from this endpoint's response refers to the V1 upload endpoint.**
 
 Sets up a metric descriptor to allow data upload. Returns the URL to allow upload.
 You only need to do this step once per conversion column you want to created.
@@ -1980,15 +2054,15 @@ To get a list of conversion columns, see the Build Reports section - "Organizati
 
 + Response 201
 
-    Note that in the response, the id is returned as `custom_conversions:{fetch id}:conversions`.
-    You can use the link to find the appropriate URL for upload in Step 3 of the conversion upload process.
+    Note that in the response, the id is returned as `custom_conversions:{fetch_id}:conversions`.
+    You can use the link to find the appropriate URL for upload in Step 2 of the conversion upload process.
 
     + Attributes
 
         + id: "custom_conversions:14:conversions" (string) - The metric name reports reports will return when providing conversion metrics for this descriptor.
         + `_links` (object)
             + `adstage:custom_conversion_upload` (object)
-                + href: "https://platform.adstage.io/api/organizations/40/metric_descriptors/14/conversions" (string) - The URL for Step 2, which will accept conversion data for this metric descriptor.
+                + href: "https://platform.adstage.io/api/organizations/40/metric_descriptors/14/conversions" (string) - The URL for Step 2, which will accept conversion data for this metric descriptor. Note that because this endpoint is currently equivalent to the V1 endpoint, this link will point to the V1 conversion upload endpoint - if using features from the V2 endpoint, AdStage currently recommends parsing the id number from the `id` response's `id` field, which will allow a seamless upgrade if a V2 endpoint is released, pointing to the V2 upload endpoint.
 
     + Body
 
@@ -2098,7 +2172,7 @@ The sections share a request schema, but document different schemas for the resp
 This type of report will return one row of metric data per requested entity with metrics aggregated across the requested timeframe.
 
 Note however that the `results` and `summary` sections of the endpoint are independent - for example, it is possible to request `row` formatted results and a `series` formatted summary.
-The [Time Series Report](time-series-report) section describes the response shapes of any components using that format.
+The Time Series Report section describes the response shapes of any components using that format.
 
 Providing the optional `aggregate_by` key will also change the response by adding a single bulk array time series data for all metrics.
 This is shaped differently than time series data in a `series` formatted request, which splits out timeseries data into one array per metric, giving just that metric's datapoints.
@@ -2126,7 +2200,7 @@ This is shaped differently than time series data in a `series` formatted request
 
             An AdStage date range string indicating the period to report data for.
 
-            See the [list of allowed relative or absolute date strings](date-ranges) in API Concepts.
+            See the list of allowed relative or absolute date strings in the Date Ranges section.
 
         + `output_format`: "row", "series" (enum[string], required)
 
@@ -2156,7 +2230,7 @@ This is shaped differently than time series data in a `series` formatted request
 
                 + targets: "/network/adstage/folder/5555", "/network/adstage/account_group/333", "/network/adwords/account/2332" (array[string]) - An optional list of AdStage Entity IDs to pull a report for, if not included all data available for the organization will be used. This can be a list of account groups, accounts, folders, campaigns, ad groups, ads, or keywords, so long as they are a coarser grouping than the `"entity_level"` specifies (e.g. if a campaign is given in this array and `"entity_level"` is set to `"ad_group"`, AdStage will report on all of the ad groups in the given campaign).
 
-                + networks: "adwords", "bing_ads", "facebook", "linkedin", "twitter" (array[string], required) - The list of networks to report data for; must contain at least one network.
+                + networks: "adwords", "amazon", "bing_ads", "facebook", "linkedin", "pinterest", "quora", "spotify", "twitter" (array[string], required) - The list of networks to report data for; must contain at least one network.
 
                 + `entity_level`: "accounts", "campaigns", `"ad_groups"`, "ads", "keywords" (enum, required) - The entity level for which the report should return data.
 
@@ -2164,7 +2238,7 @@ This is shaped differently than time series data in a `series` formatted request
 
             A non-empty list of metrics or meta fields to include in the result.
 
-            See [instructions on discovering fields](discovering-metrics) for a comprehensive list of allowed options.
+            See the Discovering Metrics section (under V1) for a comprehensive list of allowed options.
 
         + filters (array) - A set of filters to limit the results by using AND conditions.
             + (object) - A filter object. Results are only returned if filter computes to true.
@@ -2663,7 +2737,7 @@ This is shaped differently than time series data in a `series` formatted request
 This type of report will return one row of metric data per requested entity with a time series split out of that entity's metrics data.
 
 Note however that the `results` and `summary` sections of the endpoint are independent - for example, it is possible to request `row` formatted results and a `series` formatted summary.
-The [Rows Report](rows-report) section describes the response shapes of any components using that format.
+The Rows Report section describes the response shapes of any components using that format.
 
 Be advised that in addition to `series` reports, `row` reports can also provide time series data, though with a different shape.
 In contrast to the `series` formatted request, which splits out timeseries data into several arrays of time series (one series per metric), `row` reports are optionally able to give a single array of objects containing each metric's datapoints.
@@ -2691,7 +2765,7 @@ In contrast to the `series` formatted request, which splits out timeseries data 
 
             An AdStage date range string indicating the period to report data for.
 
-            See the [list of allowed relative or absolute date strings](date-ranges) in API Concepts.
+            See the Date Ranges section in API Concepts.
 
         + `output_format`: "row", "series" (enum[string], required)
 
@@ -2721,7 +2795,7 @@ In contrast to the `series` formatted request, which splits out timeseries data 
 
                 + targets: "/network/adstage/folder/5555", "/network/adstage/account_group/333", "/network/adwords/account/2332" (array[string]) - An optional list of AdStage Entity IDs to pull a report for, if not included all data available for the organization will be used. This can be a list of account groups, accounts, folders, campaigns, ad groups, ads, or keywords, so long as they are a coarser grouping than the `"entity_level"` specifies (e.g. if a campaign is given in this array and `"entity_level"` is set to `"ad_group"`, AdStage will report on all of the ad groups in the given campaign).
 
-                + networks: "adwords", "bing_ads", "facebook", "linkedin", "twitter" (array[string], required) - The list of networks to report data for; must contain at least one network.
+                + networks: "adwords", "amazon", "bing_ads", "facebook", "linkedin", "pinterest", "quora", "spotify", "twitter" (array[string], required) - The list of networks to report data for; must contain at least one network.
 
                 + `entity_level`: "accounts", "campaigns", `"ad_groups"`, "ads", "keywords" (enum, required) - The entity level for which the report should return data.
 
@@ -2729,7 +2803,7 @@ In contrast to the `series` formatted request, which splits out timeseries data 
 
             A non-empty list of metrics or meta fields to include in the result.
 
-            See [instructions on discovering fields](discovering-metrics) for a comprehensive list of allowed options.
+            See the Discovering Metrics section (under V1) for a comprehensive list of allowed options.
 
         + filters (array) - A set of filters to limit the results by using AND conditions.
             + (object) - A filter object. Results are only returned if filter computes to true.

--- a/apiary.apib
+++ b/apiary.apib
@@ -1059,7 +1059,7 @@ Gives information about various URLs associated with an ad.
 #### UTM Tracking Information
 
 **Note: UTM tracking information is only available if AdStage Join has been added to your AdStage plan and a Join task has been completed for the entity.
-Currently, Join available only as a paid Add-On.**
+Currently, Join is available only as a paid Add-On.**
 
 Gives information about the UTM parameters associated with the entity.
 Note that AdStage stores these parameters formatted as JSON in `tracking_params`.
@@ -2062,7 +2062,7 @@ To get a list of conversion columns, see the Build Reports section - "Organizati
         + id: "custom_conversions:14:conversions" (string) - The metric name reports reports will return when providing conversion metrics for this descriptor.
         + `_links` (object)
             + `adstage:custom_conversion_upload` (object)
-                + href: "https://platform.adstage.io/api/organizations/40/metric_descriptors/14/conversions" (string) - The URL for Step 2, which will accept conversion data for this metric descriptor. Note that because this endpoint is currently equivalent to the V1 endpoint, this link will point to the V1 conversion upload endpoint - if using features from the V2 endpoint, AdStage currently recommends parsing the id number from the `id` response's `id` field, which will allow a seamless upgrade if a V2 endpoint is released, pointing to the V2 upload endpoint.
+                + href: "https://platform.adstage.io/api/organizations/40/metric_descriptors/14/conversions" (string) - The URL for Step 2, which will accept conversion data for this metric descriptor. Note that because this endpoint is currently equivalent to the V1 endpoint, this link will point to the V1 conversion upload endpoint - if using features from the V2 endpoint, AdStage currently recommends parsing the id number from the response's `id` field, which will allow a seamless upgrade if a V2 endpoint is released, pointing to the V2 upload endpoint.
 
     + Body
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,857 @@
+{
+  "name": "api-documentation",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@sindresorhus/is": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
+      "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "cacheable-request": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
+      "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+      "dev": true,
+      "requires": {
+        "clone-response": "1.0.2",
+        "get-stream": "3.0.0",
+        "http-cache-semantics": "3.8.1",
+        "keyv": "3.0.0",
+        "lowercase-keys": "1.0.0",
+        "normalize-url": "2.0.1",
+        "responselike": "1.0.2"
+      },
+      "dependencies": {
+        "lowercase-keys": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+          "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
+          "dev": true
+        }
+      }
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "dev": true,
+      "requires": {
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
+      }
+    },
+    "clone-regexp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-1.0.1.tgz",
+      "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
+      "dev": true,
+      "requires": {
+        "is-regexp": "^1.0.0",
+        "is-supported-regexp-flag": "^1.0.0"
+      }
+    },
+    "clone-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.2.tgz",
+      "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "decode-uri-component": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "duplexer3": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
+    },
+    "error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dev": true,
+      "requires": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "dev": true,
+      "requires": {
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "from2": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
+      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0"
+      }
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
+    },
+    "got": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
+      "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+      "dev": true,
+      "requires": {
+        "@sindresorhus/is": "^0.7.0",
+        "cacheable-request": "^2.1.1",
+        "decompress-response": "^3.3.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "into-stream": "^3.1.0",
+        "is-retry-allowed": "^1.1.0",
+        "isurl": "^1.0.0-alpha5",
+        "lowercase-keys": "^1.0.0",
+        "mimic-response": "^1.0.0",
+        "p-cancelable": "^0.4.0",
+        "p-timeout": "^2.0.1",
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1",
+        "timed-out": "^4.0.1",
+        "url-parse-lax": "^3.0.0",
+        "url-to-options": "^1.0.1"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
+      "dev": true
+    },
+    "has-symbol-support-x": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
+      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
+      "dev": true
+    },
+    "has-to-string-tag-x": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
+      "dev": true,
+      "requires": {
+        "has-symbol-support-x": "^1.4.1"
+      }
+    },
+    "hercule": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/hercule/-/hercule-4.1.1.tgz",
+      "integrity": "sha512-ws8KMjT6SZU8jbdq+w3/O0aSdEDxKCXyhYQkAKknvadhzcLf5Qw413laK0UjhWM9jxwCr3nYsbTYVYbOIWK5+g==",
+      "dev": true,
+      "requires": {
+        "async": "^2.1.4",
+        "clone-regexp": "^1.0.0",
+        "duplexer3": "^0.1.4",
+        "get-stream": "^3.0.0",
+        "got": "^8.0.0",
+        "isstream": "^0.1.2",
+        "left-split": "^1.0.0",
+        "lodash": "^4.0.0",
+        "meow": "^3.7.0",
+        "source-map": "^0.6.0",
+        "through2": "^2.0.0",
+        "through2-get": "^0.1.0"
+      }
+    },
+    "hosted-git-info": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+      "dev": true
+    },
+    "http-cache-semantics": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
+      "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "dev": true,
+      "requires": {
+        "repeating": "^2.0.0"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "into-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
+      "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+      "dev": true,
+      "requires": {
+        "from2": "^2.1.1",
+        "p-is-promise": "^1.1.0"
+      }
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+      "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "is-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
+      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
+    "is-retry-allowed": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
+    },
+    "is-supported-regexp-flag": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-supported-regexp-flag/-/is-supported-regexp-flag-1.0.1.tgz",
+      "integrity": "sha512-3vcJecUUrpgCqc/ca0aWeNu64UGgxcvO60K/Fkr1N6RSvfGCTU60UKN68JDmKokgba0rFFJs12EnzOQa14ubKQ==",
+      "dev": true
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
+    },
+    "isurl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
+      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
+      "dev": true,
+      "requires": {
+        "has-to-string-tag-x": "^1.2.0",
+        "is-object": "^1.0.1"
+      }
+    },
+    "json-buffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
+      "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+      "dev": true
+    },
+    "keyv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
+      "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+      "dev": true,
+      "requires": {
+        "json-buffer": "3.0.0"
+      }
+    },
+    "left-split": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/left-split/-/left-split-1.0.0.tgz",
+      "integrity": "sha1-vsUUwjz7TJV6mXTt/aOFvFlyiAY=",
+      "dev": true
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "dev": true,
+      "requires": {
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
+      }
+    },
+    "lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "dev": true
+    },
+    "meow": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "dev": true,
+      "requires": {
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
+      }
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "normalize-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
+      "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^2.0.0",
+        "query-string": "^5.0.1",
+        "sort-keys": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "p-cancelable": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
+      "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
+      "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
+      "dev": true
+    },
+    "p-timeout": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
+      "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+      "dev": true,
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "dev": true,
+      "requires": {
+        "error-ex": "^1.2.0"
+      }
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+      "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "dev": true,
+      "requires": {
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+      "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        }
+      }
+    },
+    "pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "prepend-http": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+      "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "query-string": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
+      "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
+      "dev": true,
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "object-assign": "^4.1.0",
+        "strict-uri-encode": "^1.0.0"
+      }
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "dev": true,
+      "requires": {
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
+      }
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+      "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
+    "redent": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "dev": true,
+      "requires": {
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
+      }
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
+      "requires": {
+        "is-finite": "^1.0.0"
+      }
+    },
+    "resolve": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "responselike": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
+      "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+      "dev": true,
+      "requires": {
+        "lowercase-keys": "^1.0.0"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "sort-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
+      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+      "dev": true,
+      "requires": {
+        "is-plain-obj": "^1.0.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "spdx-correct": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-exceptions": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
+      "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+      "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "dev": true,
+      "requires": {
+        "is-utf8": "^0.2.0"
+      }
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "dev": true,
+      "requires": {
+        "get-stdin": "^4.0.1"
+      }
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "through2-get": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/through2-get/-/through2-get-0.1.0.tgz",
+      "integrity": "sha512-hlySS8S0Xr75MJ8BvTKiGegiJD4V08lJVPO0qzFzx/1XJCkSbn9q2secwiYkoa6jvaHOwF5eAKOutdEXRnKGXg==",
+      "dev": true,
+      "requires": {
+        "lodash.get": "^4.0.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "dev": true
+    },
+    "url-parse-lax": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+      "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+      "dev": true,
+      "requires": {
+        "prepend-http": "^2.0.0"
+      }
+    },
+    "url-to-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
+      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "api-documentation",
   "version": "1.0.0",
   "devDependencies": {
-    "hercule": "~4.1.1"
+    "hercule": "~4.1.1",
+    "lodash": "^4.17.13"
   }
 }

--- a/src/adstage_api_concepts/entity_ids.apib
+++ b/src/adstage_api_concepts/entity_ids.apib
@@ -10,10 +10,16 @@ To generate the entity id by hand, use the following string template:
 
 + The `{network}` variable must be be one of:
     + `adwords`
+    + `amazon`
     + `bing_ads`
-    + `twitter`
-    + `linkedin`
     + `facebook`
+    + `gemini` (not available in cross-network reporting; see Build Report V1)
+    + `google_analytics` (not available in cross-network reporting; see Build Report V1)
+    + `linkedin`
+    + `pinterest`
+    + `quora`
+    + `spotify`
+    + `twitter`
     + `adstage` (with entities managed on the AdStage platform: `account_group`, `user`, `organization` and `folder`)
 + The `{entity_level}` variable must be one of:
     + `account`

--- a/src/v1/building_reports/organization_create_build_report__basic.apib
+++ b/src/v1/building_reports/organization_create_build_report__basic.apib
@@ -24,7 +24,7 @@ This type of report will return one row per requested entity with metrics aggreg
         + `date_range`: "last 30 days" (string, required)
 
             An AdStage date range string.
-            See the [Date Ranges](date-ranges) section for details about allowed date range formats.
+            See the Date Ranges section for details about allowed date range formats.
 
         + limit: 10 (number) - number of rows to include
         + `sort_by`: "clicks" (string) - metric name/meta name to sort by

--- a/src/v1/building_reports/organization_create_build_report__timeseries.apib
+++ b/src/v1/building_reports/organization_create_build_report__timeseries.apib
@@ -26,7 +26,7 @@ The request is the same as a standard report but using the `"aggregate_by"` opti
         + `date_range`: "last 30 days" (string, required)
 
             An AdStage date range string.
-            See the [Date Ranges](date-ranges) section for details about allowed date range formats.
+            See the Date Ranges section for details about allowed date range formats.
 
         + limit: 10 (number) - number of rows to include
         + `sort_by`: "clicks" (string) - metric name/meta name to sort by

--- a/src/v1/custom_conversions/organization_create_metric_descriptor.apib
+++ b/src/v1/custom_conversions/organization_create_metric_descriptor.apib
@@ -2,7 +2,7 @@
 
 Creates a custom metric descriptor to allow data upload and returns the URL which will accept metric data for the new descriptor.
 This step only needs to be performed once per conversion column - the metric descriptor can be reused across multiple data uploads.
-To get a list of existing conversion columns, see the [Discovering Metrics](discovering-metrics) section.
+To get a list of existing conversion columns, see the Discovering Metrics section.
 
 + Parameters
 
@@ -31,15 +31,15 @@ To get a list of existing conversion columns, see the [Discovering Metrics](disc
 
 + Response 201
 
-    Note that in the response, the id is returned as `custom_conversions:{fetch id}:conversions`.
-    You can use the link to find the appropriate URL for upload in Step 3 of the conversion upload process.
+    Note that in the response, the id is returned as `custom_conversions:{fetch_id}:conversions`.
+    You can use the link to find the appropriate URL for upload in Step 2 of the conversion upload process.
 
     + Attributes
 
-        + id: "custom_conversions:14:conversions" (string) - the raw metric name returned in reports (see [Getting Report](#reference/0/building-reports/getting-report) )
+        + id: "custom_conversions:14:conversions" (string) - the raw metric id returned in reports (see the Building Reports section)
         + `_links` (object)
             + `adstage:custom_conversion_upload` (object)
-                + href: "https://platform.adstage.io/api/organizations/40/metric_descriptors/14/conversions" (string) - the URL for step 3.
+                + href: "https://platform.adstage.io/api/organizations/40/metric_descriptors/14/conversions" (string) - the URL for uploading data in step 2.
 
     + Body
 

--- a/src/v1/custom_conversions/organization_index_metric_descriptors.apib
+++ b/src/v1/custom_conversions/organization_index_metric_descriptors.apib
@@ -40,16 +40,22 @@ Additionally, AdStage will automatically derive several metrics that are listed 
                 + tooltip: "Clicks shows how many times a user clicked on your ad" (string) - additional details about a metric, if available
                 + format: "DEFAULT", "PERCENTAGE", "CURRENCY", "TEXT", "DECIMAL", "INTEGER" (enum[string]) - format for the metric (default is `INTEGER`)
                 + type: "METRIC", "TEXT" (enum[string]) - whether the descriptor is for a metric or metadata
-                + `is_adwords`: true (string) - if the metric is valid for the adwords network
-                + `is_facebook`: true (string) - if the metric is valid for the facebook network
-                + `is_linkedin`: true (string) - if the metric is valid for the linkedin network
-                + `is_bing_ads`: true (string) - if the metric is valid for the bing ads network
-                + `is_twitter`: true (string) - if the metric is valid for the twitter network
-                + `is_account`: true (string) - if the metric is valid for the account reporting level
-                + `is_campaign`: true (string) - if the metric is valid for the campaign reporting level
-                + `is_ad_group`: true (string) - if the metric is valid for the ad group reporting level
-                + `is_ad`: true (string) - if the metric is valid for the ad reporting level
-                + `is_keyword`: true (string) - if the metric is valid for keyword reporting level
+                + `is_adwords`: true (boolean) - if the metric is valid for the `adwords` network
+                + `is_amazon`: true (boolean) - if the metric is valid for the `amazon` network
+                + `is_bing_ads`: true (boolean) - if the metric is valid for the `bing_ads` network
+                + `is_facebook`: true (boolean) - if the metric is valid for the `facebook` network
+                + `is_gemini`: false (boolean) - if the metric is valid for the `gemini` network
+                + `is_google_analytics`: false (boolean) - if the metric is valid for the `google_analytics` network
+                + `is_linkedin`: true (boolean) - if the metric is valid for the `linkedin` network
+                + `is_pinterest`: true (boolean) - if the metric is valid for the `pinterest` network
+                + `is_quora`: true (boolean) - if the metric is valid for the `quora` network
+                + `is_spotify`: true (boolean) - if the metric is valid for the `spotify` network
+                + `is_twitter`: true (boolean) - if the metric is valid for the twitter network
+                + `is_account`: true (boolean) - if the metric is valid for the account reporting level
+                + `is_campaign`: true (boolean) - if the metric is valid for the campaign reporting level
+                + `is_ad_group`: true (boolean) - if the metric is valid for the ad group reporting level
+                + `is_ad`: true (boolean) - if the metric is valid for the ad reporting level
+                + `is_keyword`: true (boolean) - if the metric is valid for keyword reporting level
 
     + Body
 
@@ -65,9 +71,15 @@ Additionally, AdStage will automatically derive several metrics that are listed 
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": true,
+                    "is_amazon": true,
                     "is_bing_ads": true,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": true,
+                    "is_pinterest": true,
+                    "is_quora": true,
+                    "is_spotify": true,
                     "is_twitter": true,
                     "is_account": true,
                     "is_campaign": true,
@@ -88,9 +100,15 @@ Additionally, AdStage will automatically derive several metrics that are listed 
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": true,
+                    "is_amazon": true,
                     "is_bing_ads": true,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": true,
+                    "is_pinterest": true,
+                    "is_quora": true,
+                    "is_spotify": true,
                     "is_twitter": true,
                     "is_account": true,
                     "is_campaign": true,
@@ -111,9 +129,15 @@ Additionally, AdStage will automatically derive several metrics that are listed 
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": true,
+                    "is_amazon": true,
                     "is_bing_ads": true,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": true,
+                    "is_pinterest": true,
+                    "is_quora": true,
+                    "is_spotify": true,
                     "is_twitter": true,
                     "is_account": true,
                     "is_campaign": true,

--- a/src/v1/custom_conversions/organization_metric_descriptor_create_conversions.apib
+++ b/src/v1/custom_conversions/organization_metric_descriptor_create_conversions.apib
@@ -24,14 +24,14 @@ Alternatively, the V2 endpoint implements an automatic roll up feature.
             + (object)
                 + `timestamp`: `"2016-02-03T03:40Z"` (string, required) - ISO8061 formatted string representing when the conversion occurred.
                 + `value`: 30.5 (number) - An optional conversion value, expressed in the currency type for the converting account. Used to compute Return on Ad Spend.
-                + `attribution` - A list of key/value pairs where the key is an [AdStage Entity ID](entity-ids) and the value is a multiplier of how much to weigh the conversion. Use 1 unless you want to do multi-touch attribution modeling.
+                + `attribution` - A list of key/value pairs where the key is an AdStage Entity ID and the value is a multiplier of how much to weigh the conversion. Use 1 unless you want to do multi-touch attribution modeling.
                     + `/network/adwords/campaign/530303`: 1 (number) - (this id is just an example; use valid ids)
                     + `/network/adwords/acount/530303`: 1 (number) - (this id is just an example; use valid ids)
 
         + `date_range`: `"last 30 days"` (string, required)
 
             An AdStage date range string.
-            See the [Date Ranges](date-ranges) section for details about allowed date range formats.
+            See the Date Ranges section for details about allowed date range formats.
 
     + Body
 

--- a/src/v1/discovering_metrics/index_metric_descriptors.apib
+++ b/src/v1/discovering_metrics/index_metric_descriptors.apib
@@ -22,16 +22,22 @@ This endpoint provides information on the names and formats of cross-channel (`a
                 + tooltip: "Clicks shows how many times a user clicked on your ad" (string) - additional details about a metric, if available
                 + format: "DEFAULT", "PERCENTAGE", "CURRENCY", "TEXT", "DECIMAL", "INTEGER" (enum[string]) - format for the metric (default is `INTEGER`)
                 + type: "METRIC", "TEXT" (enum[string]) - whether the descriptor is for a metric or metadata
-                + `is_adwords`: true (string) - if the metric is valid for the adwords network
-                + `is_facebook`: true (string) - if the metric is valid for the facebook network
-                + `is_linkedin`: true (string) - if the metric is valid for the linkedin network
-                + `is_bing_ads`: true (string) - if the metric is valid for the bing ads network
-                + `is_twitter`: true (string) - if the metric is valid for the twitter network
-                + `is_account`: true (string) - if the metric is valid for the account reporting level
-                + `is_campaign`: true (string) - if the metric is valid for the campaign reporting level
-                + `is_ad_group`: true (string) - if the metric is valid for the ad group reporting level
-                + `is_ad`: true (string) - if the metric is valid for the ad reporting level
-                + `is_keyword`: true (string) - if the metric is valid for keyword reporting level
+                + `is_adwords`: true (boolean) - if the metric is valid for the `adwords` network
+                + `is_amazon`: true (boolean) - if the metric is valid for the `amazon` network
+                + `is_bing_ads`: true (boolean) - if the metric is valid for the `bing_ads` network
+                + `is_facebook`: true (boolean) - if the metric is valid for the `facebook` network
+                + `is_gemini`: false (boolean) - if the metric is valid for the `gemini` network
+                + `is_google_analytics`: false (boolean) - if the metric is valid for the `google_analytics` network
+                + `is_linkedin`: true (boolean) - if the metric is valid for the `linkedin` network
+                + `is_pinterest`: true (boolean) - if the metric is valid for the `pinterest` network
+                + `is_quora`: true (boolean) - if the metric is valid for the `quora` network
+                + `is_spotify`: true (boolean) - if the metric is valid for the `spotify` network
+                + `is_twitter`: true (boolean) - if the metric is valid for the `twitter` network
+                + `is_account`: true (boolean) - if the metric is valid for the account reporting level
+                + `is_campaign`: true (boolean) - if the metric is valid for the campaign reporting level
+                + `is_ad_group`: true (boolean) - if the metric is valid for the ad group reporting level
+                + `is_ad`: true (boolean) - if the metric is valid for the ad reporting level
+                + `is_keyword`: true (boolean) - if the metric is valid for keyword reporting level
 
     + Body
 
@@ -47,9 +53,15 @@ This endpoint provides information on the names and formats of cross-channel (`a
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": true,
+                    "is_amazon": true,
                     "is_bing_ads": true,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": true,
+                    "is_pinterest": true,
+                    "is_quora": true,
+                    "is_spotify": true,
                     "is_twitter": true,
                     "is_account": true,
                     "is_campaign": true,
@@ -69,9 +81,15 @@ This endpoint provides information on the names and formats of cross-channel (`a
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": true,
+                    "is_amazon": true,
                     "is_bing_ads": true,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": true,
+                    "is_pinterest": true,
+                    "is_quora": true,
+                    "is_spotify": true,
                     "is_twitter": true,
                     "is_account": true,
                     "is_campaign": true,
@@ -91,9 +109,15 @@ This endpoint provides information on the names and formats of cross-channel (`a
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": true,
+                    "is_amazon": true,
                     "is_bing_ads": true,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": true,
+                    "is_pinterest": true,
+                    "is_quora": true,
+                    "is_spotify": true,
                     "is_twitter": true,
                     "is_account": true,
                     "is_campaign": true,

--- a/src/v1/discovering_metrics/meta_fields.apib
+++ b/src/v1/discovering_metrics/meta_fields.apib
@@ -136,7 +136,7 @@ To request a single, flattened objective field, append a dot and the key name, s
 Gives information about the type or subtype for an entity as designated by the remote network.
 For example, a LinkedIn campaign may have the `campaign_type` of `SSU`, a LinkedIn API designated campaign type.
 Note that the `type` field is an exception and refers to an AdStage generated entity category, such as `network_ad`, rather than a remote network designated category.
-See [Entity IDs](entity-ids) for more information.
+See the Entity IDs section for more information.
 
 | UI Display Name        | API Field Name                 |
 | ---------------------- | ------------------------------ |
@@ -180,6 +180,9 @@ Gives information about various URLs associated with an ad.
 | Tracking Template      | `tracking_url_template`        |
 
 #### UTM Tracking Information
+
+**Note: UTM tracking information is only available if AdStage Join has been added to your AdStage plan and a Join task has been completed for the entity.
+Currently, Join available only as a paid Add-On.**
 
 Gives information about the UTM parameters associated with the entity.
 Note that AdStage stores these parameters formatted as JSON in `tracking_params`.

--- a/src/v1/discovering_metrics/meta_fields.apib
+++ b/src/v1/discovering_metrics/meta_fields.apib
@@ -182,7 +182,7 @@ Gives information about various URLs associated with an ad.
 #### UTM Tracking Information
 
 **Note: UTM tracking information is only available if AdStage Join has been added to your AdStage plan and a Join task has been completed for the entity.
-Currently, Join available only as a paid Add-On.**
+Currently, Join is available only as a paid Add-On.**
 
 Gives information about the UTM parameters associated with the entity.
 Note that AdStage stores these parameters formatted as JSON in `tracking_params`.

--- a/src/v1/discovering_metrics/metric_descriptors_show_network.apib
+++ b/src/v1/discovering_metrics/metric_descriptors_show_network.apib
@@ -28,28 +28,32 @@ Additionally, non-AdStage network provider metrics do not distinguish between me
         + descriptors (array)
             + (object)
                 + id: "clicks" (string) - the identifier assigned to the metric in reports
-                + short_name: "Clicks" (string) - a short human readable name for the metric
-                + display_names: ["Clicks"] (array[string]) - the network's list of allowable human readable display names for the metric; this key is omitted unless `adwords` was specified for the `network` param
+                + `short_name`: "Clicks" (string) - a short human readable name for the metric
+                + `display_names`: ["Clicks"] (array[string]) - the network's list of allowable human readable display names for the metric; this key is omitted unless `adwords` was specified for the `network` param
                 + name: "Clicks" (string) - the full human readable name for the metric used in AdStage UIs
                 + tooltip: "Clicks shows how many times a user clicked on your ad" (string) - additional details about a metric, if available
                 + format: "DEFAULT", "PERCENTAGE", "CURRENCY", "TEXT", "DECIMAL", "INTEGER" (enum[string]) - format for the metric (default is `INTEGER`)
                 + type: "METRIC", "TEXT" (enum[string]) - whether the descriptor is for a metric or metadata
-                + can_filter: true (boolean) - if the metric is allowed to be used in a filter field for a reporting request; this key is omitted unless `gemini` was specified for the `network` param
+                + `can_filter`: true (boolean) - if the metric is allowed to be used in a filter field for a reporting request; this key is omitted unless `gemini` was specified for the `network` param
                 + supports_filters: ["ACCOUNT_PERFORMANCE_REPORT"] (array[string]) - a list of all reports on the provider's network that allow filtering on the metric; this key is omitted unless `adwords` was specified for the `network` param
                 + supports_zero_impressions: ["ACCOUNT_PERFORMANCE_REPORT"] (array[string]) - a list of all reports on the provider's network that maintain metrics even when the ad entity has not logged any impressions; this key is omitted unless `adwords` was specified for the `network` param
                 + reports: ["ACCOUNT_PERFORMANCE_REPORT"] (array[string]) - a list of all reports on the provider's network that provide data for the metric; this key is omitted unless `adwords` was specified for the `network` param
-                + is_adwords: true (boolean) - if the metric is valid for the Google Ads network
-                + is_bing_ads: true (boolean) - if the metric is valid for the Microsoft Ads network
-                + is_facebook: true (boolean) - if the metric is valid for the Facebook network
-                + is_gemini: false (boolean) - if the metric is valid for the Gemini network; this key is omitted unless `gemini` was specified for the `network` param
-                + is_google_analytics: false (boolean) - if the metric is valid for the Google Analytics network; this key is omitted unless `google_analytics` was specified for the `network` param
-                + is_linkedin: true (boolean) - if the metric is valid for the LinkedIn network
-                + is_twitter: true (boolean) - if the metric is valid for the Twitter network
-                + is_account: true (boolean) - if the metric is valid for the account reporting level
-                + is_campaign: true (boolean) - if the metric is valid for the campaign reporting level
-                + is_ad_group: true (boolean) - if the metric is valid for the ad group reporting level
-                + is_ad: true (boolean) - if the metric is valid for the ad reporting level
-                + is_keyword: true (boolean) - if the metric is valid for keyword reporting level
+                + `is_adwords`: true (boolean) - if the metric is valid for the `adwords` network
+                + `is_amazon`: true (boolean) - if the metric is valid for the `amazon` network
+                + `is_bing_ads`: true (boolean) - if the metric is valid for the `bing_ads` network
+                + `is_facebook`: true (boolean) - if the metric is valid for the `facebook` network
+                + `is_gemini`: false (boolean) - if the metric is valid for the `gemini` network
+                + `is_google_analytics`: false (boolean) - if the metric is valid for the `google_analytics` network
+                + `is_linkedin`: true (boolean) - if the metric is valid for the `linkedin` network
+                + `is_pinterest`: true (boolean) - if the metric is valid for the `pinterest` network
+                + `is_quora`: true (boolean) - if the metric is valid for the `quora` network
+                + `is_spotify`: true (boolean) - if the metric is valid for the `spotify` network
+                + `is_twitter`: true (boolean) - if the metric is valid for the `twitter` network
+                + `is_account`: true (boolean) - if the metric is valid for the account reporting level
+                + `is_campaign`: true (boolean) - if the metric is valid for the campaign reporting level
+                + `is_ad_group`: true (boolean) - if the metric is valid for the ad group reporting level
+                + `is_ad`: true (boolean) - if the metric is valid for the ad reporting level
+                + `is_keyword`: true (boolean) - if the metric is valid for keyword reporting level
 
     + Body
 
@@ -65,9 +69,15 @@ Additionally, non-AdStage network provider metrics do not distinguish between me
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": false,
+                    "is_amazon": false,
                     "is_bing_ads": false,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": false,
+                    "is_pinterest": false,
+                    "is_quora": false,
+                    "is_spotify": false,
                     "is_twitter": false,
                     "is_account": true,
                     "is_campaign": true,
@@ -89,9 +99,15 @@ Additionally, non-AdStage network provider metrics do not distinguish between me
                     "category": "PERFORMANCE",
                     "default_sort_order": "DESC",
                     "is_adwords": false,
+                    "is_amazon": false,
                     "is_bing_ads": false,
                     "is_facebook": true,
+                    "is_gemini": false,
+                    "is_google_analytics": false,
                     "is_linkedin": false,
+                    "is_pinterest": false,
+                    "is_quora": false,
+                    "is_spotify": false,
                     "is_twitter": false,
                     "is_account": true,
                     "is_campaign": true,

--- a/src/v2/building_reports/organization_create_build_report__rows.apib
+++ b/src/v2/building_reports/organization_create_build_report__rows.apib
@@ -3,7 +3,7 @@
 This type of report will return one row of metric data per requested entity with metrics aggregated across the requested timeframe.
 
 Note however that the `results` and `summary` sections of the endpoint are independent - for example, it is possible to request `row` formatted results and a `series` formatted summary.
-The [Time Series Report](time-series-report) section describes the response shapes of any components using that format.
+The Time Series Report section describes the response shapes of any components using that format.
 
 Providing the optional `aggregate_by` key will also change the response by adding a single bulk array time series data for all metrics.
 This is shaped differently than time series data in a `series` formatted request, which splits out timeseries data into one array per metric, giving just that metric's datapoints.
@@ -31,7 +31,7 @@ This is shaped differently than time series data in a `series` formatted request
 
             An AdStage date range string indicating the period to report data for.
 
-            See the [list of allowed relative or absolute date strings](date-ranges) in API Concepts.
+            See the list of allowed relative or absolute date strings in the Date Ranges section.
 
         + `output_format`: "row", "series" (enum[string], required)
 
@@ -61,7 +61,7 @@ This is shaped differently than time series data in a `series` formatted request
 
                 + targets: "/network/adstage/folder/5555", "/network/adstage/account_group/333", "/network/adwords/account/2332" (array[string]) - An optional list of AdStage Entity IDs to pull a report for, if not included all data available for the organization will be used. This can be a list of account groups, accounts, folders, campaigns, ad groups, ads, or keywords, so long as they are a coarser grouping than the `"entity_level"` specifies (e.g. if a campaign is given in this array and `"entity_level"` is set to `"ad_group"`, AdStage will report on all of the ad groups in the given campaign).
 
-                + networks: "adwords", "bing_ads", "facebook", "linkedin", "twitter" (array[string], required) - The list of networks to report data for; must contain at least one network.
+                + networks: "adwords", "amazon", "bing_ads", "facebook", "linkedin", "pinterest", "quora", "spotify", "twitter" (array[string], required) - The list of networks to report data for; must contain at least one network.
 
                 + `entity_level`: "accounts", "campaigns", `"ad_groups"`, "ads", "keywords" (enum, required) - The entity level for which the report should return data.
 
@@ -69,7 +69,7 @@ This is shaped differently than time series data in a `series` formatted request
 
             A non-empty list of metrics or meta fields to include in the result.
 
-            See [instructions on discovering fields](discovering-metrics) for a comprehensive list of allowed options.
+            See the Discovering Metrics section (under V1) for a comprehensive list of allowed options.
 
         + filters (array) - A set of filters to limit the results by using AND conditions.
             + (object) - A filter object. Results are only returned if filter computes to true.

--- a/src/v2/building_reports/organization_create_build_report__timeseries.apib
+++ b/src/v2/building_reports/organization_create_build_report__timeseries.apib
@@ -3,7 +3,7 @@
 This type of report will return one row of metric data per requested entity with a time series split out of that entity's metrics data.
 
 Note however that the `results` and `summary` sections of the endpoint are independent - for example, it is possible to request `row` formatted results and a `series` formatted summary.
-The [Rows Report](rows-report) section describes the response shapes of any components using that format.
+The Rows Report section describes the response shapes of any components using that format.
 
 Be advised that in addition to `series` reports, `row` reports can also provide time series data, though with a different shape.
 In contrast to the `series` formatted request, which splits out timeseries data into several arrays of time series (one series per metric), `row` reports are optionally able to give a single array of objects containing each metric's datapoints.
@@ -31,7 +31,7 @@ In contrast to the `series` formatted request, which splits out timeseries data 
 
             An AdStage date range string indicating the period to report data for.
 
-            See the [list of allowed relative or absolute date strings](date-ranges) in API Concepts.
+            See the Date Ranges section in API Concepts.
 
         + `output_format`: "row", "series" (enum[string], required)
 
@@ -61,7 +61,7 @@ In contrast to the `series` formatted request, which splits out timeseries data 
 
                 + targets: "/network/adstage/folder/5555", "/network/adstage/account_group/333", "/network/adwords/account/2332" (array[string]) - An optional list of AdStage Entity IDs to pull a report for, if not included all data available for the organization will be used. This can be a list of account groups, accounts, folders, campaigns, ad groups, ads, or keywords, so long as they are a coarser grouping than the `"entity_level"` specifies (e.g. if a campaign is given in this array and `"entity_level"` is set to `"ad_group"`, AdStage will report on all of the ad groups in the given campaign).
 
-                + networks: "adwords", "bing_ads", "facebook", "linkedin", "twitter" (array[string], required) - The list of networks to report data for; must contain at least one network.
+                + networks: "adwords", "amazon", "bing_ads", "facebook", "linkedin", "pinterest", "quora", "spotify", "twitter" (array[string], required) - The list of networks to report data for; must contain at least one network.
 
                 + `entity_level`: "accounts", "campaigns", `"ad_groups"`, "ads", "keywords" (enum, required) - The entity level for which the report should return data.
 
@@ -69,7 +69,7 @@ In contrast to the `series` formatted request, which splits out timeseries data 
 
             A non-empty list of metrics or meta fields to include in the result.
 
-            See [instructions on discovering fields](discovering-metrics) for a comprehensive list of allowed options.
+            See the Discovering Metrics section (under V1) for a comprehensive list of allowed options.
 
         + filters (array) - A set of filters to limit the results by using AND conditions.
             + (object) - A filter object. Results are only returned if filter computes to true.

--- a/src/v2/custom_conversions/organization_create_metric_descriptor.apib
+++ b/src/v2/custom_conversions/organization_create_metric_descriptor.apib
@@ -44,7 +44,7 @@ To get a list of conversion columns, see the Build Reports section - "Organizati
         + id: "custom_conversions:14:conversions" (string) - The metric name reports reports will return when providing conversion metrics for this descriptor.
         + `_links` (object)
             + `adstage:custom_conversion_upload` (object)
-                + href: "https://platform.adstage.io/api/organizations/40/metric_descriptors/14/conversions" (string) - The URL for Step 2, which will accept conversion data for this metric descriptor. Note that because this endpoint is currently equivalent to the V1 endpoint, this link will point to the V1 conversion upload endpoint - if using features from the V2 endpoint, AdStage currently recommends parsing the id number from the `id` response's `id` field, which will allow a seamless upgrade if a V2 endpoint is released, pointing to the V2 upload endpoint.
+                + href: "https://platform.adstage.io/api/organizations/40/metric_descriptors/14/conversions" (string) - The URL for Step 2, which will accept conversion data for this metric descriptor. Note that because this endpoint is currently equivalent to the V1 endpoint, this link will point to the V1 conversion upload endpoint - if using features from the V2 endpoint, AdStage currently recommends parsing the id number from the response's `id` field, which will allow a seamless upgrade if a V2 endpoint is released, pointing to the V2 upload endpoint.
 
     + Body
 

--- a/src/v2/custom_conversions/organization_create_metric_descriptor.apib
+++ b/src/v2/custom_conversions/organization_create_metric_descriptor.apib
@@ -2,7 +2,8 @@
 
 **Note that this endpoint is identical to the V1 endpoint.
 Its documentation has been copied here for convenience in explaining the custom conversion upload flow.
-AdStage may choose to release a V2 namespaced endpoint with a different feature set and shape in the future.**
+AdStage may choose to release a V2 namespaced endpoint with a different feature set and shape in the future.
+Given this, note that the link returned from this endpoint's response refers to the V1 upload endpoint.**
 
 Sets up a metric descriptor to allow data upload. Returns the URL to allow upload.
 You only need to do this step once per conversion column you want to created.
@@ -35,15 +36,15 @@ To get a list of conversion columns, see the Build Reports section - "Organizati
 
 + Response 201
 
-    Note that in the response, the id is returned as `custom_conversions:{fetch id}:conversions`.
-    You can use the link to find the appropriate URL for upload in Step 3 of the conversion upload process.
+    Note that in the response, the id is returned as `custom_conversions:{fetch_id}:conversions`.
+    You can use the link to find the appropriate URL for upload in Step 2 of the conversion upload process.
 
     + Attributes
 
         + id: "custom_conversions:14:conversions" (string) - The metric name reports reports will return when providing conversion metrics for this descriptor.
         + `_links` (object)
             + `adstage:custom_conversion_upload` (object)
-                + href: "https://platform.adstage.io/api/organizations/40/metric_descriptors/14/conversions" (string) - The URL for Step 2, which will accept conversion data for this metric descriptor.
+                + href: "https://platform.adstage.io/api/organizations/40/metric_descriptors/14/conversions" (string) - The URL for Step 2, which will accept conversion data for this metric descriptor. Note that because this endpoint is currently equivalent to the V1 endpoint, this link will point to the V1 conversion upload endpoint - if using features from the V2 endpoint, AdStage currently recommends parsing the id number from the `id` response's `id` field, which will allow a seamless upgrade if a V2 endpoint is released, pointing to the V2 upload endpoint.
 
     + Body
 


### PR DESCRIPTION
**Overview**
- Remove internal document links because APIary does not suppor that currently
- Update Gemini and Google Analytics network booleans for consistency across all platforms
- Clarify that UTMs are only available to Join customers after a successful Join
- Add amazon, pinterest, quora, and spotify network booleans uniformly to metric descriptor endpoints

**Acceptance Criteria**
Paste `apiary.apib` into the [APIary editor](https://app.apiary.io/adstageapi/editor) and verify:
- [ ] Internal links are removed
- [ ] `amazon`, `gemini`, `google_analytics`, `pinterest`, `quora`, and `spotify` Network booleans are documented for all metric descriptor endpoints.
- [ ] UTM availability message is correct
- [ ] No regressions in the rest of the documentation

**Dependent PRs**
Platform https://github.com/AdStage/adstage-platform-v2/pull/4837
Proxy https://github.com/AdStage/adstage-proxy/pull/92

**Review Box**
(Implements changes for network boolean consistency)
http://ec2-107-20-40-91.compute-1.amazonaws.com:3000/