### PR TITLE
Db 5121 folder names without org

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -943,8 +943,10 @@ Use the `GET /me` endpoint to get the current user ID.
 | ---------------------- | ------------------------------ | ----------------- |
 | Account Group ID       | `account_group_id`             |                   |
 | Account Group Name     | `account_group_name`           |                   |
-| Folder ID              | `folder_names.{id}`            | `folder_names.40` |
-| Folder Name            | `folder_ids.{id}`              | `folder_ids.40`   |
+| Folder Name            | `folder_names.{id}`            | `folder_names.40` |
+| Folder ID              | `folder_ids.{id}`              | `folder_ids.40`   |
+
+*Note that `folder_names` and `folder_ids` will automatically infer your the requesting user's ID, though data will still be returned under the fully qualified field name (e.g. a request for `folder_names` might list results under `folder_names.40`).*
 
 #### Long IDs
 

--- a/src/v1/discovering_metrics/meta_fields.apib
+++ b/src/v1/discovering_metrics/meta_fields.apib
@@ -55,8 +55,10 @@ Use the `GET /me` endpoint to get the current user ID.
 | ---------------------- | ------------------------------ | ----------------- |
 | Account Group ID       | `account_group_id`             |                   |
 | Account Group Name     | `account_group_name`           |                   |
-| Folder ID              | `folder_names.{id}`            | `folder_names.40` |
-| Folder Name            | `folder_ids.{id}`              | `folder_ids.40`   |
+| Folder Name            | `folder_names.{id}`            | `folder_names.40` |
+| Folder ID              | `folder_ids.{id}`              | `folder_ids.40`   |
+
+*Note that `folder_names` and `folder_ids` will automatically infer your the requesting user's ID, though data will still be returned under the fully qualified field name (e.g. a request for `folder_names` might list results under `folder_names.40`).*
 
 #### Long IDs
 


### PR DESCRIPTION
**Overview:**
Documents ability for users to request `folder_names` as a metric and receive the `folder_names.{{org}}` result back automatically.

**Related PR's:**
- Platform: https://github.com/AdStage/adstage-platform-v2/pull/5136
- API Docs: https://github.com/AdStage/api-documentation/pull/9

